### PR TITLE
disable to use 'l' when opening help view

### DIFF
--- a/gui/help.go
+++ b/gui/help.go
@@ -132,6 +132,8 @@ func (h *Help) UpdateView(panel Panel) {
 func (h *Help) Keybinding(gui *Gui) {
 	h.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		switch event.Rune() {
+		case 'l':
+			return nil
 		case 'q':
 			gui.Pages.RemovePage("help")
 			gui.FocusPanel(gui.CurrentPanel)


### PR DESCRIPTION
When the terminal width is not enough, the help description is cut off lengthwise and 'l' key shows unnecessarily behavior like below.

![before](https://user-images.githubusercontent.com/16238709/77827783-fa62dd80-715a-11ea-9749-69edcf91ee64.gif)

I fixed that by minor change.